### PR TITLE
Use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ inputs:
 #   time: # id of output
 #     description: 'The time we greeted you'
 runs:
-  using: 'node12'
+  using: 'node16'
   pre: 'dist/pre.js'
   main: 'dist/main.js'
   post: 'dist/post.js'


### PR DESCRIPTION
[GitHub Actions: All Actions will begin running on Node16 instead of Node12 | GitHub Changelog](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)